### PR TITLE
Add missing dependency

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -72,6 +72,7 @@ setup(
         'kazoo',           # ZooKeeper api
         'six',
         'pendulum',
+        'tzlocal'
     ],
     classifiers=[
         "Development Status :: 5 - Production/Stable",


### PR DESCRIPTION
Installing this on a fresh machine results in an error loading the solrzkutil module.

```
cris.barbero@C02VT0W1HTD7 ~/projects$ solr-zkutil
solrzkutil python package is not installed.

cris.barbero@C02VT0W1HTD7 ~/projects$ python
Python 2.7.15 (default, May  1 2018, 16:44:08)
[GCC 4.2.1 Compatible Apple LLVM 9.1.0 (clang-902.0.39.1)] on darwin
Type "help", "copyright", "credits" or "license" for more information.
>>> import solrzkutil
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/usr/local/lib/python2.7/site-packages/solrzkutil/__init__.py", line 25, in <module>
    from tzlocal import get_localzone
ImportError: No module named tzlocal
```